### PR TITLE
Revert to `composite-metazoan.owl`

### DIFF
--- a/config/collectdata/vfb_fullontologies.txt
+++ b/config/collectdata/vfb_fullontologies.txt
@@ -1,2 +1,2 @@
-http://purl.obolibrary.org/obo/uberon/composite-metazoan-basic.owl
-https://raw.githubusercontent.com/EBISPOT/scxa_2_cxg/main/efo_slice.owl
+http://purl.obolibrary.org/obo/uberon/composite-metazoan.owl
+https://github.com/EBISPOT/scxa_2_cxg/raw/main/efo_slice.owl


### PR DESCRIPTION
Previous `composite-metazoan.owl` had an issue with an annotation from species-specific ontology. Now the fix is available in the latest Uberon release, so we can finaly use the artefact.

Fixes #1